### PR TITLE
Bump nodejs version to current recommended LTS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	],
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
-			"version": "14"
+			"version": "18"
 		},
 		"ghcr.io/devcontainers/features/azure-cli:1": {
 			"version": "latest"


### PR DESCRIPTION
NodeJS 14 is out of support
See https://github.com/nodejs/release#release-schedule
